### PR TITLE
selectable callback URL

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -29,14 +29,14 @@ form:
 
     site_callback_url:
       type: text
-      disabled: true
+      readonly: true
       label: PLUGIN_LOGIN_OAUTH2.SITE_CALLBACK_URI
       help: PLUGIN_LOGIN_OAUTH2.SITE_CALLBACK_URI_HELP
       data-default@: ['Grav\Plugin\Login\OAuth2\Providers\BaseProvider::getCallbackUri', false]
 
     admin_callback_url:
       type: text
-      disabled: true
+      readonly: true
       label: PLUGIN_LOGIN_OAUTH2.ADMIN_CALLBACK_URI
       help: PLUGIN_LOGIN_OAUTH2.ADMIN_CALLBACK_URI_HELP
       data-default@: ['Grav\Plugin\Login\OAuth2\Providers\BaseProvider::getCallbackUri', true]


### PR DESCRIPTION
Callback URL are intended to be copied into OpenId provider configuration.
Make them focusable/selectable.