### PR TITLE
Avoid misleanding connection screen if no provider is setup

### DIFF
--- a/login-oauth2.php
+++ b/login-oauth2.php
@@ -125,7 +125,9 @@ class LoginOauth2Plugin extends Plugin
      */
     public function onLoginPage()
     {
-        $this->grav['login']->addProviderLoginTemplate('login-oauth2/login-oauth2.html.twig');
+        if ($this->grav['oauth2']->getProviders()) {
+            $this->grav['login']->addProviderLoginTemplate('login-oauth2/login-oauth2.html.twig');
+        }
     }
 
     /**


### PR DESCRIPTION
If no provider is enabled for site connections, simply omit the template instead of showing "Login with one of these available social accounts..." followed by nothing.