### PR TITLE
Remove user scope for github by default

### DIFF
--- a/login-oauth2.yaml
+++ b/login-oauth2.yaml
@@ -15,7 +15,7 @@ providers:
     client_id: ''
     client_secret: ''
     options:
-      scope: ['user', 'user:email']
+      scope: ['user:email']
 
   instagram:
     enabled: true


### PR DESCRIPTION
From https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/:
user: 'Grants read/write access to profile info only. Note that this scope includes user:email and user:follow.'

So we need to either use `read:user` or remove it completely. I removed it here for the default configuration.