### PR TITLE
Show buggy provider

### DIFF
--- a/classes/ProviderFactory.php
+++ b/classes/ProviderFactory.php
@@ -16,7 +16,7 @@ class ProviderFactory
         $provider_classname = 'Grav\\Plugin\\Login\\OAuth2\\Providers\\' . ucfirst($provider) . 'Provider';
 
         if (!class_exists($provider_classname)) {
-            throw new \RuntimeException('Invalid OAuth2 provider');
+            throw new \RuntimeException('Invalid OAuth2 provider:' . $provider);
         }
 
         $class = new $provider_classname();
@@ -30,7 +30,7 @@ class ProviderFactory
         $provider_classname = 'Grav\\Plugin\\Login\\OAuth2\\Providers\\' . ucfirst($provider) . 'Provider';
 
         if (!class_exists($provider_classname)) {
-            throw new \RuntimeException('Invalid OAuth2 provider');
+            throw new \RuntimeException('Invalid OAuth2 provider:' . $provider);
         }
 
         return $provider_classname::checkIfActive($options);


### PR DESCRIPTION
Happened because you removed `gitlab` provider in 2.x (moved into login-oauth2-extras without any changelog/notice)
But my configuration still have it (Even if disabled, it broke my website)